### PR TITLE
Update docs from ImportBasePath change

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -76,7 +76,7 @@ To use this SDK in your Go project, run the following command:
 
 You can then use the SDK in your Go code with:
 
-  import "github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3"
+  import "github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3/random"
 
 ```
 
@@ -171,7 +171,7 @@ random.Pet("hi")
 package main
 
 import (
-	"github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3"
+	"github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 


### PR DESCRIPTION
See https://github.com/pulumi/pulumi-terraform-bridge/pull/2705

That changed the ImportBasePath used for Go packages to match up what sdk-gen currently writes in terms of folder structure.

This updates the docs so the import statments match.