### PR TITLE
We don't need to run pulumi-terraform-bridge's tests

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,5 @@
 project_name: pulumi-terraform-provider
 version: 2
-before:
-  hooks:
-  - "make -C dynamic test"
 builds:
 - dir: dynamic
   env:


### PR DESCRIPTION
These tests have already been run before the commit we are releasing has merged. These tests might not be self-contained, and depend on upstream's installed providers. Release is currently failing because we don't install the relevant providers before running the test.