### PR TITLE
Remove cache-dependency-path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
-        cache-dependency-path: "dynamic/go.sum"
     - name: Install Pulumi CLI
       uses: pulumi/actions@v5
     - name: Build pulumi-terraform-provider


### PR DESCRIPTION
This will let `actions/setup-go@v5` use the default path: `/go.sum`, which is what we want since `dynamic/go.mod` was removed.