### PR TITLE
Fix dynamic binary version linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 go.work
 go.work.sum
+.idea/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   - arm64
   ignore: []
   ldflags:
-  - "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore -X github.com/pulumi/pulumi-terraform-bridge/dynamic/version.version={{.Tag}}"
+  - "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore -X github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/version.version={{.Tag}}"
   binary: pulumi-resource-terraform-provider
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
Fixes #54.

When we [removed the Go module for the dynamic package](https://github.com/pulumi/pulumi-terraform-bridge/pull/2755), this changed the import name of the dynamic package from `github.com/pulumi/pulumi-terraform-bridge/dynamic` to `github.com/pulumi/pulumi-terraform-bridge/v3/dynamic.

But we did not change the path name in the Goreleaser, so all versions past that change used the default version `v0.0.0-dev` instead. This affects versions 0.5.2 through 0.5.4.

Once this fix is merged, we should cut a new minor release.

- **ignore intellij files**
- **Use bridge v3 module version when linking the dynamic binary version**
