### PR TITLE
Update _index.md

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -21,7 +21,7 @@ As an example, let's depend directly on Hashicorp's [terraform-provider-random](
 
 {{% notes type="info" %}}
 
-You will need to be using a version of Pulumi >= 3.130.0.
+You will need to be using a version of Pulumi >= 3.147.0.
 
 {{% /notes %}}
 


### PR DESCRIPTION
Per https://github.com/pulumi/pulumi/pull/18428, the minimum required Pulumi version for at least the Go SDK to build correctly is v3.147.0.

This should be displayed on the registry page for this provider.

Additionally, after merge, this provider needs a patch release.