### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: release
 on:
   push:
@@ -6,16 +7,21 @@ on:
     - "!v*.*.*-**"
 
 env:
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-  PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   GOVERSION: 1.21.x
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: PULUMI_ACCESS_TOKEN,PUBLISH_REPO_USERNAME=OSSRH_USERNAME,PUBLISH_REPO_PASSWORD=OSSRH_PASSWORD
 
 jobs:
   prerequisites:
     runs-on: ubuntu-latest
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Ensure Tag (not branch)
       run: |
         if [ "${{ github.ref_type }}" != "tag" ]; then exit 1; fi
@@ -51,8 +57,7 @@ jobs:
         fi
     - run: git status --porcelain
     - name: Tar provider binary
-      run: tar -zcf ${{ github.workspace }}/pulumi-terraform-provider.tar.gz -C ${{
-        github.workspace}}/dynamic/bin/ pulumi-resource-terraform-provider
+      run: tar -zcf ${{ github.workspace }}/pulumi-terraform-provider.tar.gz -C ${{ github.workspace}}/dynamic/bin/ pulumi-resource-terraform-provider
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -62,6 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: prerequisites
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Download provider
       uses: actions/download-artifact@v4
       with:
@@ -73,6 +81,9 @@ jobs:
     permissions:
       contents: write
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -128,10 +139,13 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Dispatch Metadata build
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           repository: pulumi/registry
           event-type: resource-provider
           client-payload: |-


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
