### PR TITLE
Attempt to fix publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
-    permissions:
-      contents: write
     steps:
     - name: Fetch secrets from ESC
       id: esc-secrets


### PR DESCRIPTION
It looks like https://github.com/pulumi/pulumi-terraform-provider/pull/76 broke publishing (its the only change between
[v0.11.0](https://github.com/pulumi/pulumi-terraform-provider/actions/runs/14627927079) and
[v0.12.0](https://github.com/pulumi/pulumi-terraform-provider/actions/runs/15927171646).

My working theory is that the `publish.permissions` block over-wrote the extremely broad permissions that #76 gave to all jobs (`write-all`). When the workflow was written, the default permission was read, so `permissions: { content: write }` was more permissive then the default.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/81