### PR TITLE
Force Goreleaser git tag to avoid tripping over existing tags in the real bridge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
       #
       # We are running a release in the bridge git repo, but not releasing the bridge, so
       # we add a local tag to work around GoReleaser.
-      run: cd ${{ github.workspace }}/bridge && git tag "${{ github.ref_name }}"
+      run: cd ${{ github.workspace }}/bridge && git tag -f "${{ github.ref_name }}"
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:


### PR DESCRIPTION
This pull request changes the `release` workflow to use `git tag --force`.

Because we're using this repo as the front for the `dynamic` package, we're doing two things:

1. Releasing the `dynamic` package in the bridge
2. Tagging this repo with a version and passing it to Goreleaser to bake into the binary.

We've added a step to add a "local" tag to the checked out bridge repo in CI. However, the checked out repo will still have all of its _own_ tags. When the requested pulumi-terraform-provider tag matches an already existing tag in the bridge, the step [fails](https://github.com/pulumi/pulumi-terraform-provider/actions/runs/18571350325/job/52945985231). This has been the case for all pulumi-terraform-provider releases so far, because the bridge doesn't have any prerelease tags. But when an attempt was made to tag v1.0.0 on this repo, CI attempted to add a tag in the bridge that already exists.

Importantly, all of this is only a workaround for the Goreleaser. The code being packaged and released is not sourced from any bridge tags. 

Prerequisite to https://github.com/pulumi/pulumi-terraform-provider/issues/93.


