### PR TITLE
Remove public beta warning

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -6,13 +6,6 @@ layout: package
 
 Pulumi's `terraform-provider` can be used to generate full Pulumi SDKs for *any* Terraform provider.
 
-{{% notes type="warning" %}}
-
-This provider is in Public Beta. We are still making breaking changes to nail down the
-final design.
-
-{{% /notes %}}
-
 Any feedback is welcome! Please file suggestions and bugs at [pulumi/pulumi-terraform-provider](https://github.com/pulumi/pulumi-terraform-provider/issues).
 
 ## Example


### PR DESCRIPTION
Followup to #93. The public beta warning should be removed from the registry landing page.
Note: In order to ship these changes to the registry, a patch release must be pushed.

