### PR TITLE
ci: upgrade GitHub Actions to address Node.js 20 deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-  GOVERSION: 1.21.x
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi
   ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
@@ -26,15 +25,15 @@ jobs:
       run: |
         if [ "${{ github.ref_type }}" != "tag" ]; then exit 1; fi
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: pulumi/pulumi-terraform-bridge
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: ${{ env.GOVERSION }}
+        go-version-file: go.mod
     - name: Install Pulumi CLI
-      uses: pulumi/actions@v5
+      uses: pulumi/actions@v7
     - name: Build pulumi-terraform-provider
       run: VERSION="${{ github.ref_name }}" make -C dynamic build
     - name: Check worktree clean
@@ -59,7 +58,7 @@ jobs:
     - name: Tar provider binary
       run: tar -zcf ${{ github.workspace }}/pulumi-terraform-provider.tar.gz -C ${{ github.workspace}}/dynamic/bin/ pulumi-resource-terraform-provider
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pulumi-terraform-provider.tar.gz
         path: ${{ github.workspace }}/pulumi-terraform-provider.tar.gz
@@ -71,7 +70,7 @@ jobs:
       id: esc-secrets
       uses: pulumi/esc-action@v1
     - name: Download provider
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: pulumi-terraform-provider.tar.gz
         path: ${{ github.workspace }}/bin
@@ -83,13 +82,13 @@ jobs:
       id: esc-secrets
       uses: pulumi/esc-action@v1
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: pulumi/pulumi-terraform-bridge
         fetch-depth: 0
         path: ${{ github.workspace }}/bridge
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         path: ${{ github.workspace }}/repo


### PR DESCRIPTION
## Summary

GitHub is deprecating Node.js 20 on Actions runners — the default switches to Node.js 24 on 2026-06-02, and Node.js 20 is removed entirely on 2026-09-16 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The `prerequisites` and `test` jobs in `release.yml` were emitting deprecation warnings for several actions.

### Action upgrades

Each action was bumped to its latest major version, which runs on Node.js 24:

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | v4 | v6 |
| `actions/setup-go` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `pulumi/actions` | v5 | v7 |

`pulumi/esc-action` is already at its latest major (v1) so it is unchanged.

### Breaking-change review

I reviewed the major-version changelogs against how this workflow uses each action:

- **checkout v5/v6**: Node 24 runtime; v6 persists creds to a separate file. No code-affecting changes for us.
- **setup-go v6**: Stricter toolchain handling + Node 24. See the GOVERSION change below.
- **upload-artifact v5–v7**: Node 24 + ESM + a new opt-in `archive: false` mode. We use defaults; unaffected.
- **download-artifact v5–v8**: The v5 path-change for single-artifact downloads only affects `artifact-ids:` callers (we use `name:`). v8 now **errors by default** on digest mismatch (was warn) — worth being aware of if we see new release failures. ESM and non-zip handling are transparent to us.
- **pulumi/actions v6/v7**: v6 changed `refresh` behavior, v7 is Node 24. We only use it to install the Pulumi CLI, so neither matters here.

GitHub-hosted `ubuntu-latest` runners satisfy the Node 24 runner requirement (v2.327.1+).

### GOVERSION cleanup

`GOVERSION` was hardcoded to `1.21.x` and had drifted — the bridge's `go.mod` now declares `go 1.25.9`. Rather than re-pinning, this PR uses `setup-go`'s `go-version-file: go.mod` to read the version directly from the checked-out bridge, so the workflow tracks the bridge automatically going forward. The `GOVERSION` env var is removed.

## Test plan

- [ ] Tag a release (or dry-run via workflow re-run) and confirm deprecation warnings are gone.
- [ ] Confirm the built `pulumi-resource-terraform-provider` binary still works (artifact uploads, downloads, and GoReleaser publish succeed).
- [ ] Verify the Go version picked up by `setup-go` matches `pulumi-terraform-bridge`'s `go.mod`.