### PR TITLE
ci: upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,16 @@ jobs:
     steps:
     - name: Fetch secrets from ESC
       id: esc-secrets
-      uses: pulumi/esc-action@v1
+      uses: pulumi/esc-action@v3
     - name: Ensure Tag (not branch)
       run: |
         if [ "${{ github.ref_type }}" != "tag" ]; then exit 1; fi
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: pulumi/pulumi-terraform-bridge
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version-file: go.mod
     - name: Install Pulumi CLI
@@ -68,7 +68,7 @@ jobs:
     steps:
     - name: Fetch secrets from ESC
       id: esc-secrets
-      uses: pulumi/esc-action@v1
+      uses: pulumi/esc-action@v3
     - name: Download provider
       uses: actions/download-artifact@v8
       with:
@@ -80,15 +80,15 @@ jobs:
     steps:
     - name: Fetch secrets from ESC
       id: esc-secrets
-      uses: pulumi/esc-action@v1
+      uses: pulumi/esc-action@v3
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: pulumi/pulumi-terraform-bridge
         fetch-depth: 0
         path: ${{ github.workspace }}/bridge
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         path: ${{ github.workspace }}/repo
@@ -118,7 +118,7 @@ jobs:
       # we add a local tag to work around GoReleaser.
       run: cd ${{ github.workspace }}/bridge && git tag -f "${{ github.ref_name }}"
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+      uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
       with:
         aws-access-key-id: ${{ steps.esc-secrets.outputs.AWS_ACCESS_KEY_ID }}
         aws-region: us-east-2
@@ -128,7 +128,7 @@ jobs:
         role-external-id: upload-pulumi-release
         role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
       with:
         args: >-
           release
@@ -148,9 +148,9 @@ jobs:
     steps:
       - name: Fetch secrets from ESC
         id: esc-secrets
-        uses: pulumi/esc-action@v1
+        uses: pulumi/esc-action@v3
       - name: Dispatch Metadata build
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           repository: pulumi/registry


### PR DESCRIPTION
Bumps each action in the release workflow to its latest available major version.

| Action | Before | After |
|--------|--------|-------|
| pulumi/esc-action | v1 | v3 |
| actions/checkout | v6 | v7 |
| actions/setup-go | v6 | v7 |
| aws-actions/configure-aws-credentials | v5.1.0 | v6.2.2 |
| goreleaser/goreleaser-action | v5.1.0 | v7.2.3 |
| peter-evans/repository-dispatch | v3 | v4 |

`pulumi/actions` (v7), `actions/upload-artifact` (v7), and `actions/download-artifact` (v8) were already at their latest major versions.

The two SHA-pinned actions (`aws-actions/configure-aws-credentials`, `goreleaser/goreleaser-action`) keep their pinning, with the SHA updated to the new tag's commit and the version comment refreshed.