### PR TITLE
Update .goreleaser.yml to GoReleaser v2 schema

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: pulumi-terraform-provider
 builds:
 - dir: dynamic
@@ -19,7 +20,7 @@ archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   id: archive
 snapshot:
-  name_template: "{{ .Tag }}-SNAPSHOT"
+  version_template: "{{ .Tag }}-SNAPSHOT"
 # changelog: { disable: true } # We pass GoReleaser a CHANGELOG to use
 release:
   extra_files:
@@ -35,6 +36,6 @@ blobs:
 - provider: s3
   region: us-west-2
   bucket: get.pulumi.com
-  folder: releases/plugins/
+  directory: releases/plugins/
   ids:
   - archive


### PR DESCRIPTION
The v1.3.0 release run (https://github.com/pulumi/pulumi-terraform-provider/actions/runs/30926427036) failed immediately in the publish job:

```
only version: 2 configuration files are supported, yours is version: 0, please update your configuration
```

The workflow pins `goreleaser-action` to `version: latest`, which now resolves to GoReleaser v2.x, and v2 refuses configs that do not declare `version: 2`.

This declares `version: 2` and applies the two v2 renames the file needs:
- `snapshot.name_template` → `snapshot.version_template`
- `blobs.folder` → `blobs.directory`

Validated locally with `goreleaser check` (v2.16.0).

The failed run died at config parsing, before building or publishing anything, so nothing was partially released. Once this merges, re-pushing the `v1.3.0` tag at the new commit will re-run the release.