### PR TITLE
Drop placeholder version from assets/schema.json

### DIFF
--- a/assets/schema.json
+++ b/assets/schema.json
@@ -1,7 +1,6 @@
 {
   "name": "terraform-provider",
   "displayName": "Any Terraform Provider",
-  "version": "0.0.0-dev",
   "description": "Use any Terraform provider with Pulumi",
   "keywords": [
     "catagory/utility"


### PR DESCRIPTION
`assets/schema.json` carries `"version": "0.0.0-dev"`. That placeholder is never stamped at release time, and the registry reads the file straight from the release tag, so it reaches the registry service verbatim.

The service compares it against the version being published and rejects the mismatch:

```
POST /registry/packages/pulumi/pulumi/terraform-provider/versions/1.3.0/complete
-> 400 Bad Request: Schema version (0.0.0-dev) must match query parameter version (1.3.0)
```

Every release of this provider since the registry moved to `registry-mirror-publish` has failed this way (v1.1.2, v1.1.3, v1.1.4, v1.2.0, v1.2.1, v1.3.0) and only landed because pulumi/registry falls back to the legacy `push-registry.py`, which silently rewrites the version before publishing. That fallback is on its way out.

Bridged providers don't stamp a version into the committed schema at all — `pulumi-random`, `pulumi-cloudflare`, `pulumi-docker`, `pulumi-kubernetes` and `pulumi-command` all omit the field, and the service then takes the version from the publish request. This drops the placeholder to match, which fixes every future release without touching the release workflow.
