### PR TITLE
Fix the spelling of the category keyword

### DIFF
--- a/assets/schema.json
+++ b/assets/schema.json
@@ -3,7 +3,7 @@
   "displayName": "Any Terraform Provider",
   "description": "Use any Terraform provider with Pulumi",
   "keywords": [
-    "catagory/utility"
+    "category/utility"
   ],
   "logoUrl": "https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png",
   "meta": {


### PR DESCRIPTION
The registry reads a keyword with the `category/` prefix to set the package category. `catagory/utility` did not match, so the package had no category from the schema. Since pulumi/registry#12345 the misspelled word also shows up as a search keyword for the package.

One character change in `assets/schema.json`.
